### PR TITLE
feature - Add getUsers functions with role filtering + fix validations

### DIFF
--- a/CommunityContract.sol
+++ b/CommunityContract.sol
@@ -97,7 +97,7 @@ contract CommunityContract {
 
     function registerUser() public notBanned {
         require(
-            userRoles[msg.sender] == Role.User,
+            userRoles[msg.sender] != Role.User,
             "User is already registered"
         );
         userRoles[msg.sender] = Role.User;
@@ -121,6 +121,7 @@ contract CommunityContract {
     function assignRole(address _user, Role _role) public onlyAdmin {
         require(_role != Role.User, "Cannot assign User role");
         require(userRoles[_user] != Role.User, "User does not exist");
+        require(userRoles[_user] != Role.Admin, "Cannot change admin role");
 
         Decision memory newDecision = Decision({
             moderator: msg.sender,

--- a/CommunityContract.sol
+++ b/CommunityContract.sol
@@ -105,7 +105,7 @@ contract CommunityContract {
     }
 
     function banUser(address _user) public onlyAdmin {
-
+        require(userRoles[_user] != Role.Admin, "Cannot ban admin");
         bannedUsers[_user] = true;
 
         Decision memory newDecision = Decision({

--- a/CommunityContract.sol
+++ b/CommunityContract.sol
@@ -45,13 +45,12 @@ contract CommunityContract {
 
     mapping(address => mapping(uint256 => bool)) public hasVoted;
     address[] public userList;
-    address[] public adminList;
 
     constructor() {
         admin = msg.sender;
         admins[msg.sender] = true;
         userRoles[msg.sender] = Role.Admin;
-        adminList.push(msg.sender);
+        userList.push(msg.sender);
     }
 
     modifier onlyAdmin() {
@@ -88,6 +87,7 @@ contract CommunityContract {
     function addAdmin(address _newAdmin) public onlyAdmin {
         admins[_newAdmin] = true;
         userRoles[_newAdmin] = Role.Admin;
+        userList.push(_newAdmin);
     }
 
     function createRole(address _user, Role _role) public onlyAdmin {
@@ -105,6 +105,7 @@ contract CommunityContract {
     }
 
     function banUser(address _user) public onlyAdmin {
+
         bannedUsers[_user] = true;
 
         Decision memory newDecision = Decision({
@@ -193,10 +194,6 @@ contract CommunityContract {
         VoteResult storage result = appealVoteResults[_appealIndex];
         result.votesInFavor = appealVote.votesInFavor;
         result.votesAgainst = appealVote.votesAgainst;
-    }
-
-    function getAdmins() public view returns (address[] memory) {
-        return adminList;
     }
 
     function getUsers(Role _role) public view returns (address[] memory) {

--- a/CommunityContract.sol
+++ b/CommunityContract.sol
@@ -44,11 +44,14 @@ contract CommunityContract {
     }
 
     mapping(address => mapping(uint256 => bool)) public hasVoted;
+    address[] public userList;
+    address[] public adminList;
 
     constructor() {
         admin = msg.sender;
         admins[msg.sender] = true;
         userRoles[msg.sender] = Role.Admin;
+        adminList.push(msg.sender);
     }
 
     modifier onlyAdmin() {
@@ -98,6 +101,7 @@ contract CommunityContract {
             "User is already registered"
         );
         userRoles[msg.sender] = Role.User;
+        userList.push(msg.sender);
     }
 
     function banUser(address _user) public onlyAdmin {
@@ -189,5 +193,29 @@ contract CommunityContract {
         VoteResult storage result = appealVoteResults[_appealIndex];
         result.votesInFavor = appealVote.votesInFavor;
         result.votesAgainst = appealVote.votesAgainst;
+    }
+
+    function getAdmins() public view returns (address[] memory) {
+        return adminList;
+    }
+
+    function getUsers(Role _role) public view returns (address[] memory) {
+        uint256 numUsers = userList.length;
+        address[] memory addresses = new address[](numUsers);
+        uint256 count = 0;
+
+        for (uint256 i = 0; i < numUsers; i++) {
+            if (userRoles[userList[i]] == _role) {
+                addresses[count] = userList[i];
+                count++;
+            }
+        }
+
+        // Redimensionar el arreglo para eliminar las posiciones no utilizadas
+        assembly {
+            mstore(addresses, count)
+        }
+
+        return addresses;
     }
 }


### PR DESCRIPTION
When I was doing the web-based interface, I realised that I cannot list users and admins, because I cannot read a mapping easily from client

This methods needed extra validation:

- registerUser: require didn't let register new users because was accepting register from users with role user 
- banUser: this method allowed to ban an admin
- assignRole: this method allowed to change the role to an admin