### PR TITLE
Improve role management and initiateVotation

### DIFF
--- a/CommonContract.sol
+++ b/CommonContract.sol
@@ -5,6 +5,8 @@ contract CommonContract {
     enum ActionType {
         Ban,
         AssignRole,
+        PromoteUser,
+        DemoteUser,
         OtherAction
     }
 
@@ -29,9 +31,10 @@ contract CommonContract {
     }
 
     modifier onlyRegisteredUser() {
+        // find role
+        uint256 role = userRoles[msg.sender];
         require(
-            keccak256(bytes(userRoles[msg.sender])) !=
-                keccak256(bytes("Visitor")),
+            role > 0 && role < roleLevels.length,
             "Only registered users can perform this action"
         );
         _;
@@ -43,7 +46,12 @@ contract CommonContract {
     }
 
     function isUserAllowed(address _user) internal view returns (bool) {
-        return roles[userRoles[_user]] == true;
+        uint256 role = userRoles[_user];
+        if (role > 0 && role < roleLevels.length) {
+            return false;
+        }
+        return true;
+        // return roles[userRoles[_user]] == true;
     }
 
     modifier onlyUser() {
@@ -53,17 +61,29 @@ contract CommonContract {
 
     address[] public userList;
     uint256 quorum = (userList.length / 2) + 1;
-    mapping(address => string) public userRoles;
+    mapping(address => uint256) public userRoles;
     mapping(address => bool) public bannedUsers;
     mapping(string => bool) public roles;
-    mapping(address => string) public previousUserRoles;
+    mapping(address => uint256) public previousUserRoles;
+    string[] public roleLevels;
 
     function initializeRoles() internal {
         roles["Visitor"] = true;
+        roleLevels.push("Visitor"); // 0
+
         roles["Admin"] = true;
-        roles["Moderator"] = true;
-        roles["GlobalModerator"] = true;
-        roles["Collaborator"] = true;
+        roleLevels.push("Admin"); // 1
+
         roles["User"] = true;
+        roleLevels.push("User"); // 2
+
+        roles["Moderator"] = true;
+        roleLevels.push("Moderator"); // 3
+
+        roles["GlobalModerator"] = true;
+        roleLevels.push("GlobalModerator"); // 4
+
+        roles["Collaborator"] = true;
+        roleLevels.push("Collaborator"); // 5
     }
 }

--- a/CommunityContract.sol
+++ b/CommunityContract.sol
@@ -20,33 +20,35 @@ contract CommunityContract is CommonContract, DecisionsContract, UsersContract {
     constructor() {
         admin = msg.sender;
         admins[msg.sender] = true;
-        userRoles[msg.sender] = "Admin";
+        userRoles[msg.sender] = 0;
         userList.push(msg.sender);
         initializeRoles();
     }
 
     function addAdmin(address _newAdmin) public onlyAdmin {
         admins[_newAdmin] = true;
-        userRoles[_newAdmin] = "Admin";
+        userRoles[_newAdmin] = 0;
         userList.push(_newAdmin);
     }
 
     function createRole(string memory _role) public onlyAdmin {
         require(roles[_role] == false, "Role already exists");
         roles[_role] = true;
+        roleLevels.push(_role);
     }
 
-    function assignRole(address _user, string memory _role) public onlyAdmin {
+    function assignRole(address _user, uint256 _role) public onlyAdmin {
+        uint256 actualRole = userRoles[_user];
         require(
-            keccak256(bytes(_role)) != keccak256(bytes("User")),
-            "Cannot assign User role"
+            _role != actualRole,
+            "Cannot assign same role"
         );
         require(
-            keccak256(bytes(userRoles[_user])) != keccak256(bytes("User")),
+            actualRole != 0,
             "User does not exist"
         );
         require(
-            keccak256(bytes(userRoles[_user])) != keccak256(bytes("Admin")),
+            actualRole != 1,
             "Cannot change admin role"
         );
 
@@ -65,8 +67,9 @@ contract CommunityContract is CommonContract, DecisionsContract, UsersContract {
     }
 
     function banUser(address _user) public onlyAdmin {
+        uint256 actualRole = userRoles[_user];
         require(
-            keccak256(bytes(userRoles[_user])) != keccak256("Admin"),
+            actualRole != 1,
             "Cannot ban admin"
         );
         bannedUsers[_user] = true;

--- a/DecisionsContract.sol
+++ b/DecisionsContract.sol
@@ -115,13 +115,13 @@ contract DecisionsContract is CommonContract {
 
     function initiateVote(
         address _user,
-        uint256 newRole,
-        bool _isPromotion
+        uint256 newRole
     ) public onlyUser {
         require(msg.sender != _user, "User cannot vote for itself");
         require(newRole < roleLevels.length && newRole > 0, "Invalid role index");
 
         uint256 actualRole = userRoles[msg.sender];
+        bool _isPromotion = newRole > actualRole;
 
         if (_isPromotion) {
             require(

--- a/DecisionsContract.sol
+++ b/DecisionsContract.sol
@@ -95,12 +95,10 @@ contract DecisionsContract is CommonContract {
             // Reset the decision as it has been processed
             decision.appealed = false;
             if (decision.action == ActionType.Ban) {
-                userRoles[decision.user] = Role.User;
                 bannedUsers[decision.user] = false;
-            } 
-            // else if (decision.action == ActionType.AssignRole) {
-            //     userRoles[decision.user] = Role.User;
-            // }
+            } else if (decision.action == ActionType.AssignRole) {
+                userRoles[decision.user] = previousUserRoles[decision.user];
+            }
             delete appealVotes[_decisionIndex];
             delete appealVoteResults[_decisionIndex];
         } else {

--- a/UsersContract.sol
+++ b/UsersContract.sol
@@ -6,15 +6,14 @@ import "./CommonContract.sol";
 contract UsersContract is CommonContract {
     function registerUser() public notBanned {
         require(
-            keccak256(bytes(roleLevels[userRoles[msg.sender]])) ==
-                keccak256(bytes("Visitor")),
+            userRoles[msg.sender] == 0,
             "User is already registered"
         );
         userRoles[msg.sender] = 1;
         userList.push(msg.sender);
     }
 
-    function getUsers(string memory _role)
+    function getUsers(uint256 _role)
         public
         view
         returns (address[] memory)
@@ -24,10 +23,7 @@ contract UsersContract is CommonContract {
         uint256 count = 0;
 
         for (uint256 i = 0; i < numUsers; i++) {
-            if (
-                keccak256(bytes(roleLevels[userRoles[userList[i]]])) ==
-                keccak256(bytes(_role))
-            ) {
+            if (userRoles[userList[i]] == _role) {
                 addresses[count] = userList[i];
                 count++;
             }

--- a/UsersContract.sol
+++ b/UsersContract.sol
@@ -6,20 +6,28 @@ import "./CommonContract.sol";
 contract UsersContract is CommonContract {
     function registerUser() public notBanned {
         require(
-            userRoles[msg.sender] == Role.Visitor,
+            keccak256(bytes(userRoles[msg.sender])) ==
+                keccak256(bytes("Visitor")),
             "User is already registered"
         );
-        userRoles[msg.sender] = Role.User;
+        userRoles[msg.sender] = "User";
         userList.push(msg.sender);
     }
 
-    function getUsers(Role _role) public view returns (address[] memory) {
+    function getUsers(string memory _role)
+        public
+        view
+        returns (address[] memory)
+    {
         uint256 numUsers = userList.length;
         address[] memory addresses = new address[](numUsers);
         uint256 count = 0;
 
         for (uint256 i = 0; i < numUsers; i++) {
-            if (userRoles[userList[i]] == _role) {
+            if (
+                keccak256(bytes(userRoles[userList[i]])) ==
+                keccak256(bytes(_role))
+            ) {
                 addresses[count] = userList[i];
                 count++;
             }

--- a/UsersContract.sol
+++ b/UsersContract.sol
@@ -6,11 +6,11 @@ import "./CommonContract.sol";
 contract UsersContract is CommonContract {
     function registerUser() public notBanned {
         require(
-            keccak256(bytes(userRoles[msg.sender])) ==
+            keccak256(bytes(roleLevels[userRoles[msg.sender]])) ==
                 keccak256(bytes("Visitor")),
             "User is already registered"
         );
-        userRoles[msg.sender] = "User";
+        userRoles[msg.sender] = 1;
         userList.push(msg.sender);
     }
 
@@ -25,7 +25,7 @@ contract UsersContract is CommonContract {
 
         for (uint256 i = 0; i < numUsers; i++) {
             if (
-                keccak256(bytes(userRoles[userList[i]])) ==
+                keccak256(bytes(roleLevels[userRoles[userList[i]]])) ==
                 keccak256(bytes(_role))
             ) {
                 addresses[count] = userList[i];


### PR DESCRIPTION
- Using enum for roles makes more difficult to add, delete or update roles. Migrate to `mapping(address => string)`
- Initiate votation for new member's role
- Reduce complexity on validations for roles by compare two `uint256` instead of two `keccak(bytes("string"))`
- To determine a promotion or demotion (initiateVotation), compare the new role with the current role using the following condition: `if (newRole > currentRole)`.